### PR TITLE
Chore: Bump docker GitHub actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_PUBLISH == 'true' }}
         continue-on-error: true
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           # Use the secrets directly and not the validated environment DOCKERHUB_USERNAME
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -64,7 +64,7 @@ jobs:
             echo "dockerhub-tag=development-${{ matrix.platform }}"  >> $GITHUB_OUTPUT
           fi
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./
           file: docker/build/${{ matrix.platform }}/Dockerfile


### PR DESCRIPTION
Fixes the GitHub workflow `save-state` command deprecation warning.